### PR TITLE
Remove EIGEN_USE_BLAS since it slows down for almost all cases due to…

### DIFF
--- a/adelie/__init__.py
+++ b/adelie/__init__.py
@@ -4,7 +4,7 @@
 #   - Leda Guin
 #   - Ginnie Guin
 
-__version__ = "1.1.41"
+__version__ = "1.1.42"
 
 # Set environment flags before loading adelie_core
 import os

--- a/adelie/src/adelie_core.cpp
+++ b/adelie/src/adelie_core.cpp
@@ -28,6 +28,7 @@ PYBIND11_MODULE(adelie_core, m) {
 
     auto m_matrix_utils = m_matrix.def_submodule("utils", "Matrix utility submodule.");
     register_matrix_utils(m_matrix_utils);
+    register_matrix_utils_blas(m_matrix_utils);
 
     auto m_optimization = m.def_submodule("optimization", "Optimization submodule.");
     register_optimization(m_optimization);

--- a/adelie/src/decl.hpp
+++ b/adelie/src/decl.hpp
@@ -34,6 +34,7 @@ void register_configs(py::module_&);
 void register_constraint(py::module_&);
 void register_matrix(py::module_&);
 void register_matrix_utils(py::module_&);
+void register_matrix_utils_blas(py::module_&);
 void register_optimization(py::module_&);
 void register_state(py::module_&);
 void register_solver(py::module_&);

--- a/adelie/src/include/adelie_core/matrix/utils.hpp
+++ b/adelie/src/include/adelie_core/matrix/utils.hpp
@@ -800,32 +800,5 @@ void snp_phased_ancestry_block_axi(
     }
 }
 
-template <class MType, class OutType>
-void dgemtm(
-    const MType& m,
-    OutType& out,
-    size_t n_threads
-)
-{
-    using value_t = typename std::decay_t<MType>::Scalar;
-    using out_t = std::decay_t<OutType>;
-
-    static_assert(!out_t::IsRowMajor, "out must be column-major!");
-
-    const size_t n = m.rows();
-    const size_t p = m.cols();
-    const size_t n_bytes = sizeof(value_t) * n * p * p;
-    if (n_threads <= 1 || n_bytes <= Configs::min_bytes) { 
-        out.setZero();
-        out.template selfadjointView<Eigen::Lower>().rankUpdate(m.transpose());
-        out.template triangularView<Eigen::Upper>() = out.transpose();
-        return; 
-    }
-
-    Eigen::setNbThreads(n_threads);
-    out.noalias() = m.transpose() * m;
-    Eigen::setNbThreads(1);
-}
-
 } // namespace matrix
 } // namespace adelie_core

--- a/adelie/src/matrix_utils.cpp
+++ b/adelie/src/matrix_utils.cpp
@@ -18,7 +18,6 @@ void utils(py::module_& m)
     using colmat_value_t = ad::util::colmat_type<value_t>;
     using ref_rowarr_value_t = Eigen::Ref<ad::util::rowarr_type<value_t>>;
     using ref_rowmat_value_t = Eigen::Ref<rowmat_value_t>;
-    using ref_colmat_value_t = Eigen::Ref<colmat_value_t>;
     using ref_vec_value_t = Eigen::Ref<vec_value_t>;
     using ref_mvec_value_t = Eigen::Ref<mvec_value_t>;
     using cref_vec_index_t = Eigen::Ref<const vec_index_t>;
@@ -35,7 +34,6 @@ void utils(py::module_& m)
     m.def("dvzero", ad::matrix::dvzero<ref_vec_value_t>);
     m.def("ddot", ad::matrix::ddot<cref_mvec_value_t, cref_mvec_value_t, ref_vec_value_t>);
     m.def("dgemv", ad::matrix::dgemv<ad::util::operator_type::_eq, cref_colmat_value_t, cref_mvec_value_t, ref_rowmat_value_t, ref_mvec_value_t>);
-    m.def("dgemtm", ad::matrix::dgemtm<cref_colmat_value_t, ref_colmat_value_t>);
 
     m.def("bench_dvaddi", [](
         ref_vec_value_t x1,

--- a/adelie/src/matrx_utils_blas.cpp
+++ b/adelie/src/matrx_utils_blas.cpp
@@ -1,0 +1,56 @@
+#if defined(__APPLE__)
+#define EIGEN_USE_BLAS
+#endif
+#include "decl.hpp"
+#include <adelie_core/configs.hpp>
+#include <adelie_core/matrix/utils.hpp>
+
+namespace adelie_core {
+namespace matrix {
+
+template <class MType, class OutType>
+void dgemtm(
+    const MType& m,
+    OutType& out,
+    size_t n_threads
+)
+{
+    using value_t = typename std::decay_t<MType>::Scalar;
+    using out_t = std::decay_t<OutType>;
+
+    static_assert(!out_t::IsRowMajor, "out must be column-major!");
+
+    const size_t n = m.rows();
+    const size_t p = m.cols();
+    const size_t n_bytes = sizeof(value_t) * n * p * p;
+    if (n_threads <= 1 || n_bytes <= Configs::min_bytes) { 
+        out.setZero();
+        out.template selfadjointView<Eigen::Lower>().rankUpdate(m.transpose());
+        out.template triangularView<Eigen::Upper>() = out.transpose();
+        return; 
+    }
+
+    Eigen::setNbThreads(n_threads);
+    out.noalias() = m.transpose() * m;
+    Eigen::setNbThreads(1);
+}
+
+} // namespace matrix
+} // namespace adelie_core
+
+namespace ad = adelie_core;
+
+template <class ValueType=double>
+void matrix_utils_blas(py::module_& m)
+{
+    using value_t = ValueType;
+    using colmat_value_t = ad::util::colmat_type<value_t>;
+    using ref_colmat_value_t = Eigen::Ref<colmat_value_t>;
+    using cref_colmat_value_t = Eigen::Ref<const colmat_value_t>;
+    m.def("dgemtm", ad::matrix::dgemtm<cref_colmat_value_t, ref_colmat_value_t>);
+}
+
+void register_matrix_utils_blas(py::module_& m)
+{
+    matrix_utils_blas(m);
+}

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ if system_name == "Darwin":
     # augment arguments
     include_dirs += [omp_include]
     extra_compile_args += [
-        "-DEIGEN_USE_BLAS",
         "-Xpreprocessor",
         "-fopenmp",
     ]


### PR DESCRIPTION
… no inlining and only useful with large large inputs. We only need this for 1 matrix operation only used for eager_cov.