### PR TITLE
fix indexing / sorting for initializing gradient with no warm start

### DIFF
--- a/adelie/solver.py
+++ b/adelie/solver.py
@@ -284,16 +284,20 @@ def gaussian_cov(
         active_set[:active_set_size] = np.arange(active_set_size)
         rsq = 0
 
-        subset = np.array([
-            np.arange(groups[ss], groups[ss] + group_sizes[ss]) 
-            for ss in screen_set
-        ])
-        order = np.argsort(subset)
-        indices = subset[order]
-        values = screen_beta[order]
+        if screen_set.size > 0:
+            subset = np.hstack([
+                np.arange(groups[ss], groups[ss] + group_sizes[ss]) 
+                for ss in screen_set])
+            order = np.argsort(subset)
+            indices = subset[order]
+            values = screen_beta[order]
 
-        grad = np.empty(p, dtype=dtype)
-        A.mul(indices, values, grad)
+            grad = np.empty(p, dtype=dtype)
+            A.mul(indices, values, grad)
+        else:
+            # it actually just feels like this is what we might as well set as grad...
+            grad = np.zeros(p, dtype=dtype)
+            
         grad = v - grad
 
     else:


### PR DESCRIPTION
This fixes https://github.com/JamesYang007/adelie/issues/144 

But it feels like an even simpler fix is to just set `grad=np.zeros(p, dtype=dtype)` because that is what is going to happen anyways. Or is there a reason to call `A.mul` at this point?