### PR TITLE
Fix 1-ULP kkt/screen comparison disagreement causing infinite BASIL loop

### DIFF
--- a/adelie/src/include/adelie_core/solver/solver_base.hpp
+++ b/adelie/src/include/adelie_core/solver/solver_base.hpp
@@ -364,9 +364,10 @@ inline void screen(
         // previous iteration added all pivot-rule predictions and KKT still failed.
         // In this case, do the most safe thing, which is to add all failed variables.
         if ((screen_set.size() == static_cast<size_t>(old_screen_set_size)) && !all_kkt_passed) {
+            const auto l1_regul = lmda_next * alpha;
             for (int i = 0; i < abs_grad.size(); ++i) {
                 if (is_screen(i)) continue;
-                if (abs_grad[i] > lmda_next * penalty[i] * alpha) {
+                if (abs_grad[i] > l1_regul * penalty[i]) {
                     screen_set.push_back(i);
                 }
             }
@@ -422,11 +423,12 @@ bool kkt(
         return screen_hashset.find(i) != screen_hashset.end();
     };
 
+    const auto l1_regul = lmda * alpha;
     for (int k = 0; k < groups.size(); ++k) {
         if (is_screen(k)) continue;
         const auto pk = penalty[k];
         const auto abs_grad_k = abs_grad[k];
-        if (abs_grad_k > lmda * alpha * pk) return false;
+        if (abs_grad_k > l1_regul * pk) return false;
     }
 
     return true;


### PR DESCRIPTION

## Summary

In `adelie_core/solver/solver_base.hpp`, two checks of what is meant to be the same KKT-style threshold are written with different multiplication orders:

```cpp
// line 369 — screen escape valve (pivot rule)
if (abs_grad[i] > lmda_next * penalty[i] * alpha) { screen_set.push_back(i); }

// line 429 — kkt
if (abs_grad_k > lmda * alpha * pk) return false;
```

Same operands, different ordering. The C++ standard allows the compiler to emit either as `(a*b)*c` or via FMA, with different rounding. clang on Apple silicon at `-O2` produces them as **1-ULP-different doubles** for some inputs.

When `abs_grad[k]` lands exactly between the two cutoffs, `kkt()` keeps reporting "violator" while the screen escape valve keeps refusing to add the group. The outer BASIL `while(1)` at line 611 has no iteration cap and no interrupt point, so it cannot exit.

## Reprex (R)

End-user manifestation in the R wrapper [`adelie-r`](https://github.com/JamesYang007/adelie-r), against current CRAN `adelie` 1.0.8 / 1.0.9:

```r
library(adelie)
load("reprex_data.rda")        # X_train (84x100), y_train, group_starts, foldid
cv.grpnet(X_train, glm.gaussian(y_train),
          min_ratio = 0.05, foldid = foldid,
          groups = group_starts, alpha = 0.7)
# hangs at 100% CPU; setTimeLimit cannot kill it
```

`reprex_data.rda` (47 kB) is bundled in the adelie-r issue thread linked in this PR. A simpler, smaller-data reproducer also hangs:

```r
library(adelie)
load("adelie_bardet.rda")      # same X_train, y_train, group_starts
weights <- rep(1, 84); weights[5] <- 0; weights <- weights / sum(weights)
X <- matrix.dense(X_train, method = "naive", n_threads = 1)
grpnet(X, glm.gaussian(y_train, weights = weights),
       lmda_path_size = 1, groups = group_starts, alpha = 0.7, n_threads = 1)
# hangs
```

The bug is fragile to 1-ULP perturbations of any input that flows into the cutoff:

- `alpha = seq(.1, 1, by = .1)[7]` is `0x3fe6666666666667`, exactly **1 ULP above** the literal `0.7 = 0x3fe6666666666666`. With this alpha, the call completes — the cutoffs shift off the boundary value. (This is why a loop iterating `alpha = seq(.1, 1, by = .1)` in user code happily passes `0.7`-ish values that the literal `0.7` does not.)
- Rounding the supplied `lambda` sequence by 1 ULP (`round(ll, 15)`) similarly resolves it.

I have not translated the reprex to Python. The bug is in C++ template code that both bindings exercise — any Python `adelie.solver.grpnet` call that lands `abs_grad[k]` in the 1-ULP gap will hang too. Happy to add a Python regression test if you point me at the right place.

## Reprex (pure C++)

To remove any doubt that this is a wrapper-specific issue, I built a standalone C++ harness that calls `adelie_core::solver::gaussian::naive::solve` directly via the `adelie_core` templates — no R, no Python, no Rcpp / pybind11. State inputs are dumped from R bit-exactly through library calls (`X$mul(resid, weights)` etc., so every double goes through `MatrixNaiveStandardize::mul` and is bit-identical to what `grpnet()` constructs internally), serialized as little-endian binary, and read back via `fread` in C++.

```bash
# 1) dump state inputs from R (47 kB of .bin files in cpp_data/)
Rscript dump_state.R

# 2) compile cpp_reprex.cpp with R's exact flags
clang++ -arch arm64 -std=gnu++17 -DNDEBUG -O2 -fPIC -falign-functions=64 \
        -I<adelie_core_include> -I<RcppEigen>/include \
        -DEIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS \
        -o cpp_reprex cpp_reprex.cpp

# 3) run
timeout 15 ./cpp_reprex
```

Result on the unfixed `solver_base.hpp`, with an env-gated trace inside the BASIL loop (`ADELIE_TRACE=1`, `ADELIE_MAX_OUTER=3`):

```
[BASIL lambda] lmda_path_idx=0 lmda_curr=0.099441197628790598 screen_size=0
[BASIL it=1]   kkt_passed=0 active=0  top_unscreen: k=4
               abs_grad=0.15565009436337668
               cut_kkt =0.15565009436337665    (lmda * alpha * pk)
               cut_scr =0.15565009436337668    (lmda * pk * alpha)
               kkt_says_viol=1  scr_says_viol=0
[BASIL it=2,3,...]  identical line repeated; screen set never grows.
```

Bit-identical to what the R session produces. Every iteration after the first replays the same `(abs_grad, cut_kkt, cut_scr)` triple — the disagreement is deterministic per build, not flaky.

With the patch from this PR applied (and nothing else changed), the same harness completes in milliseconds. Both runs use the same compiled `cpp_reprex` binary against the same `cpp_data/*.bin`; the only difference between hang and completion is the 4-line `solver_base.hpp` change.

The dump script (`dump_state.R`), `cpp_reprex.cpp`, and `build_cpp_reprex.sh` are bundled in the adelie-r issue thread linked from this PR.

## Bit-level evidence

Captured by an env-gated trace inside `solver_base.hpp` (env vars `ADELIE_TRACE=1`, `ADELIE_MAX_OUTER=N`). At the lambda where the `cv.grpnet` reprex hangs (cumulative outer iteration 18 onward, all reporting identical state):

```
abs_grad[k=4] = 0.15565009436337668   bits = 3fc3ec57a0747b6e
cut_kkt       = 0.15565009436337665   bits = 3fc3ec57a0747b6d   (lmda * alpha * pk)
cut_scr       = 0.15565009436337668   bits = 3fc3ec57a0747b6e   (lmda * pk * alpha)
```

`cut_kkt` is exactly 1 ULP below `cut_scr`. `abs_grad` is bit-identical to `cut_scr`.

- `abs_grad > cut_kkt` → **true**  → `kkt()` returns `false` (violator)
- `abs_grad > cut_scr` → **false** → escape valve does not add the group

Same group `k=4`, same bit pattern, every iteration. Screen set stays empty; `while(1)` cannot terminate.

clang's per-call codegen depends on optimization flags and surrounding context, so the exact bits will vary between builds — but the structural property (two orderings → two possibly-different doubles → some `abs_grad` lands between) holds on any IEEE 754 platform.

## Why glmnet does not have this bug

For comparison, [`glmnetpp`](https://github.com/intro-stat-learning/glmnetpp) routes every KKT-style check through a single helper:

```cpp
// include/glmnetpp_bits/elnet_point/internal/base.hpp:90
static bool check_kkt(value_t g, value_t l1_regul, value_t penalty) {
    return g > l1_regul * penalty;
}
```

with the threshold precomputed once per outer iteration (line 175: `auto tlam = beta * (2.0 * lmda - prev_lmda)`, passed by value). Two operands at the leaf, no associativity ambiguity, no 1-ULP gap. The legacy Fortran path follows the same `tlam = bta*(2.0*alm - alm0)` precompute pattern. `adelie_core`'s design recomputes the threshold expression inline at multiple sites with different parenthesizations and is therefore exposed.

## Fix

Both call sites precompute `l1_regul = lmda * alpha` into a local and compare with `l1_regul * penalty[k]`. The 2-operand multiplication is bit-deterministic in IEEE 754 (no associativity to play with), and both functions read identical `lmda` and `alpha`, so the two `l1_regul` doubles are bit-identical and so are the comparisons.

```diff
--- a/adelie/src/include/adelie_core/solver/solver_base.hpp
+++ b/adelie/src/include/adelie_core/solver/solver_base.hpp
@@ -364,9 +364,10 @@ inline void screen(
         // previous iteration added all pivot-rule predictions and KKT still failed.
         // In this case, do the most safe thing, which is to add all failed variables.
         if ((screen_set.size() == static_cast<size_t>(old_screen_set_size)) && !all_kkt_passed) {
+            const auto l1_regul = lmda_next * alpha;
             for (int i = 0; i < abs_grad.size(); ++i) {
                 if (is_screen(i)) continue;
-                if (abs_grad[i] > lmda_next * penalty[i] * alpha) {
+                if (abs_grad[i] > l1_regul * penalty[i]) {
                     screen_set.push_back(i);
                 }
             }
@@ -422,11 +423,12 @@ bool kkt(
         return screen_hashset.find(i) != screen_hashset.end();
     };

+    const auto l1_regul = lmda * alpha;
     for (int k = 0; k < groups.size(); ++k) {
         if (is_screen(k)) continue;
         const auto pk = penalty[k];
         const auto abs_grad_k = abs_grad[k];
-        if (abs_grad_k > lmda * alpha * pk) return false;
+        if (abs_grad_k > l1_regul * pk) return false;
     }

     return true;
```

## Verification

- The R reprex above completes in milliseconds against the patched submodule; previously hangs.
- The smaller `weights[5]=0` reprex also completes; previously hangs.
- A 20-step `cv.grpnet` path with `weights[5]=0` produces a normal `min` / `1se` table with deviance climbing as expected; no regression in normal operation.
- **Pure C++ harness** (`cpp_reprex.cpp` linking only `adelie_core` headers, R's exact compile flags) against bit-exact dumped state:
  - Unfixed `solver_base.hpp` → BASIL outer iteration cap fires after 50 rounds (would hang without the diagnostic cap), with the bit-identical `(abs_grad, cut_kkt, cut_scr)` triple shown above.
  - Patched `solver_base.hpp` → completes in milliseconds with no other change.
